### PR TITLE
Reorder site:update commands

### DIFF
--- a/Task/Drush/ApplyDatabaseUpdates.php
+++ b/Task/Drush/ApplyDatabaseUpdates.php
@@ -13,7 +13,6 @@ class ApplyDatabaseUpdates extends DrushTask {
   public function run() {
     return $this->exec()
       ->arg('updatedb')
-      ->option('entity-updates')
       ->option('yes')
       ->run();
   }

--- a/Task/Site/Update.php
+++ b/Task/Site/Update.php
@@ -18,7 +18,7 @@ class Update extends BaseTask {
 
   /**
    * Environment.
-   * 
+   *
    * @var string
    */
   protected $environment;
@@ -46,20 +46,16 @@ class Update extends BaseTask {
     $collection->add((new SetupFileSystem($this->environment))->collection());
 
     $collection->add([
-      // Clear all caches.
-      'Update.cacheRebuild' => new CacheRebuild(),
-      // Import configuration.
-      'Update.drushConfigImport' => new ConfigImport(),
       // Apply database updates.
       'Update.applyDatabaseUpdates' => new ApplyDatabaseUpdates(),
-      // Import configuration (again, to ensure no stale configuration updates).
-      'Update.drushConfigImportAgain' => new ConfigImport(),
       // Apply entity schema updates.
       'Update.applyEntitySchemaUpdates' => new ApplyEntitySchemaUpdates(),
-      // Clear all caches (again).
-      'Update.cacheRebuildAgain' => new CacheRebuild(),
+      // Import configuration.
+      'Update.drushConfigImport' => new ConfigImport(),
       // Update translations.
       'Install.localeUpdate' => new LocaleUpdate(),
+      // Clear all caches.
+      'Update.cacheRebuild' => new CacheRebuild(),
     ]);
 
     return $collection;


### PR DESCRIPTION
Hi, i think it makes sense to restructure the order of commands in ``site:update``. Triggering cache rebuild on a database with invalid state could corrupt the container.

We had issue during the last acquia_contenthub update because the module renames some db tables and Drupal won't  bootstrap without these changes applied. 

ApplyDatabaseUpdates runs ``updb --entity-update`` this makes the ApplyEntitySchemaUpdates obsolete.