### PR TITLE
Adjusted check for bootstrapped status check

### DIFF
--- a/Utility/Drupal.php
+++ b/Utility/Drupal.php
@@ -215,7 +215,7 @@ class Drupal {
   protected static function statusIsBootstrapped(DrupalCoreStatus $status) {
     $bootstrap = $status->get('bootstrap');
 
-    return !empty($bootstrap) && strtolower($bootstrap) === 'successful';
+    return !empty($bootstrap);
   }
 
 }


### PR DESCRIPTION
There is problem with status check when bootstrap status is translated. Fe. on German it's "Erfolgreich", so compare to "successful" can't be used. Based on drush command code: https://github.com/drush-ops/drush/blob/8.1.11/commands/core/core.drush.inc#L591
"bootstrap" status exists only if it's bootstrapped properly and it is sufficient to check only that property is not empty.